### PR TITLE
Make sure the account living on different network don't clash

### DIFF
--- a/spirekey/src/context/AccountsContext.tsx
+++ b/spirekey/src/context/AccountsContext.tsx
@@ -216,13 +216,21 @@ const AccountsProvider = ({ children }: Props) => {
       return addAccount(account);
     const updatedAccounts = accounts.map((acc) => {
       if (account.accountName !== acc.accountName) return acc;
+      if (account.networkId !== acc.networkId) return acc;
       return account;
     });
     setAccounts(updatedAccounts);
   };
 
   const addAccount = (account: Account): void => {
-    if (accounts.some((a) => a.accountName === account.accountName)) return;
+    if (
+      accounts.some(
+        (a) =>
+          a.accountName === account.accountName &&
+          a.networkId === account.networkId,
+      )
+    )
+      return;
     setAccounts([account, ...accounts]);
   };
 

--- a/spirekey/vitest.config.mts
+++ b/spirekey/vitest.config.mts
@@ -30,10 +30,10 @@ export default defineConfig({
       ],
       provider: 'v8',
       thresholds: {
-        lines: 26.5,
-        functions: 36.13,
+        lines: 26.47,
+        functions: 35.86,
         branches: 53.96,
-        statements: 26.5,
+        statements: 26.47,
         autoUpdate: true,
       },
     },


### PR DESCRIPTION
- an account can have the same key used for different networks resulting in the same c:account. This usually only affects developers.