### PR TITLE
chore: Update Account type to include optional guard

### DIFF
--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -17,6 +17,9 @@ export type Account = {
   minRegistrationApprovals: number;
   balance: string;
   devices: Device[];
+  // The keyset refguard of the r:account, in the future,
+  // this will be a keyset, but this will only happen after coin v7
+  guard: string;
   networkId: string;
   chainIds: ChainId[];
   txQueue: QueuedTx[];

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -2,6 +2,20 @@ import type { ChainId, ITransactionDescriptor } from '@kadena/client';
 
 export type QueuedTx = ITransactionDescriptor;
 
+type RefKeyset = {
+  keysetref: {
+    ns: string;
+    ksn: string;
+  };
+};
+type Keyset = {
+  'admin-keyset': {
+    keys: string[];
+    pred: string;
+  };
+};
+export type Guard = RefKeyset | Keyset;
+
 export type OptimalTransactionsAccount = Pick<
   Account,
   'chainIds' | 'accountName' | 'networkId' | 'requestedFungibles'
@@ -19,7 +33,7 @@ export type Account = {
   devices: Device[];
   // The keyset refguard of the r:account, in the future,
   // this will be a keyset, but this will only happen after coin v7
-  guard: string;
+  guard?: Guard;
   networkId: string;
   chainIds: ChainId[];
   txQueue: QueuedTx[];

--- a/spirekey/src/components/Registration/Registration.tsx
+++ b/spirekey/src/components/Registration/Registration.tsx
@@ -77,7 +77,7 @@ export const registerNewDevice =
     };
     if (useRAccount()) {
       const keypair = genKeyPair();
-      const accountName = await getRAccountName(
+      const { name: accountName, guard } = await getRAccountName(
         publicKey,
         keypair.publicKey,
         networkId,
@@ -90,10 +90,13 @@ export const registerNewDevice =
       });
       onPasskeyRetrieved({
         accountName,
+        guard,
         networkId,
         balance: '0.0',
         alias,
-        chainIds: Array(20).fill(1).map((_, i) => i.toString()) as ChainId[],
+        chainIds: Array(20)
+          .fill(1)
+          .map((_, i) => i.toString()) as ChainId[],
         minApprovals: 1,
         minRegistrationApprovals: 1,
         devices: [

--- a/spirekey/src/context/AccountsContext.tsx
+++ b/spirekey/src/context/AccountsContext.tsx
@@ -165,6 +165,7 @@ const AccountsProvider = ({ children }: Props) => {
           }
 
           return migrateAccountStructure({
+            guard: remoteAccount.guard,
             accountName,
             networkId,
             alias,

--- a/spirekey/src/utils/shared/account.ts
+++ b/spirekey/src/utils/shared/account.ts
@@ -5,7 +5,7 @@ import {
   setMeta,
   setNetworkId,
 } from '@kadena/client/fp';
-import type { Account, Device } from '@kadena/spirekey-types';
+import type { Account, Device, Guard } from '@kadena/spirekey-types';
 
 import { assertFulfilled } from '@/utils/assertFulfilled';
 
@@ -72,10 +72,11 @@ export const getRAccountFromChain = async ({
   const account = res.result.data as {
     account: string;
     balance: string;
-    guard: any;
+    guard: Guard;
     devices: Device[];
   };
   return {
+    guard: account.guard,
     accountName: account.account,
     minApprovals: 1,
     minRegistrationApprovals: 1,


### PR DESCRIPTION
[Updated the Account type to return a guard](https://github.com/kadena-community/webauthn-wallet/commit/d93a9d58dfe9159e1a0b06b0a55bce815c395410) 

- Returning the account guard as a string because the reference guard
  returns a string
- Added an empty string as the guard for legacy c:accounts
- Added a Guard type that optionally accepts a RefKeyset or Keyset